### PR TITLE
Add annotations for dynamic map objects to distinguish better in VISAB.

### DIFF
--- a/Unity Projekt/Assets/Scripts/VISAB/Model/VISABImageContainer.cs
+++ b/Unity Projekt/Assets/Scripts/VISAB/Model/VISABImageContainer.cs
@@ -8,8 +8,11 @@ namespace Assets.Scripts.VISAB
         public byte[] MapImage { get; set; }
 
         public byte[] CityImage { get; set; }
+        public string CityAnnotation { get; set; }
         public byte[] StreetImage { get; set; }
+        public string StreetAnnotation { get; set; }
         public byte[] VillageImage { get; set; }
+        public string VillageAnnotation { get; set; }
 
     }
 }

--- a/Unity Projekt/Assets/Scripts/VISAB/VISABHelper.cs
+++ b/Unity Projekt/Assets/Scripts/VISAB/VISABHelper.cs
@@ -154,8 +154,11 @@ namespace Assets.Scripts.VISAB
             //File.WriteAllBytes("map.png", map);
 
             images.CityImage = city;
+            images.CityAnnotation = "C";
             images.StreetImage = street;
+            images.StreetAnnotation = "S";
             images.VillageImage = village;
+            images.VillageAnnotation = "V";
             images.MapImage = map;
 
             //File.WriteAllBytes(DateTime.Now.ToString("yyyy-dd-M--HH-mm-ss" + "city") + ".png", city);


### PR DESCRIPTION
As the title indicates, settlers now sends annotations for its game object images because they are not 
well distinguishable from bird-view perspective and would thus be hard to differentiate in VISABs replay view.